### PR TITLE
feat: move `esbuild` to `peerDependencies`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        esbuild: [0.14.0, 0.14, 0.15.0, 0.15, 0.16.0, 0.16, 0.17.0, 0.17, 0.18.0, 0.18]
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [14.x, 16.x, 18.x]
     runs-on: ${{matrix.os}}
@@ -19,9 +20,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7.x.x
+          version: 8
       - name: Install Dependencies
         run: pnpm install
+      - name: Install esbuild ${{ matrix.esbuild }}
+        run: pnpm install esbuild@${{ matrix.esbuild }}
       - name: Build
         run: pnpm build
       - name: Test

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   ],
   "dependencies": {
     "@jspm/core": "2.0.0-beta.24",
-    "esbuild": "^0.14.54",
     "@rollup/pluginutils": "^3.1.0",
     "local-pkg": "^0.4.3"
   },
@@ -47,6 +46,7 @@
     "@rollup/plugin-inject": "^4.0.4",
     "@types/node": "^18.15.13",
     "acorn": "^8.8.2",
+    "esbuild": "^0.14.54",
     "estree-walker": "^2.0.2",
     "magic-string": "^0.25.9",
     "resolve.exports": "^1.1.1",
@@ -54,6 +54,9 @@
     "tsup": "^6.7.0",
     "typescript": "^4.9.5",
     "vitest": "^0.16.0"
+  },
+  "peerDependencies": {
+    "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@jspm/core':
@@ -7,9 +11,6 @@ dependencies:
   '@rollup/pluginutils':
     specifier: ^3.1.0
     version: 3.1.0(rollup@2.79.1)
-  esbuild:
-    specifier: ^0.14.54
-    version: 0.14.54
   local-pkg:
     specifier: ^0.4.3
     version: 0.4.3
@@ -24,6 +25,9 @@ devDependencies:
   acorn:
     specifier: ^8.8.2
     version: 8.8.2
+  esbuild:
+    specifier: ^0.14.54
+    version: 0.14.54
   estree-walker:
     specifier: ^2.0.2
     version: 2.0.2
@@ -144,6 +148,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.17:
@@ -499,6 +504,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64@0.14.54:
@@ -507,6 +513,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64@0.14.54:
@@ -515,6 +522,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64@0.14.54:
@@ -523,6 +531,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64@0.14.54:
@@ -531,6 +540,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64@0.14.54:
@@ -539,6 +549,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32@0.14.54:
@@ -547,6 +558,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64@0.14.54:
@@ -555,6 +567,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64@0.14.54:
@@ -563,6 +576,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm@0.14.54:
@@ -571,6 +585,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le@0.14.54:
@@ -579,6 +594,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le@0.14.54:
@@ -587,6 +603,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64@0.14.54:
@@ -595,6 +612,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x@0.14.54:
@@ -603,6 +621,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64@0.14.54:
@@ -611,6 +630,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64@0.14.54:
@@ -619,6 +639,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64@0.14.54:
@@ -627,6 +648,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32@0.14.54:
@@ -635,6 +657,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64@0.14.54:
@@ -643,6 +666,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64@0.14.54:
@@ -651,6 +675,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild@0.14.54:
@@ -680,6 +705,7 @@ packages:
       esbuild-windows-32: 0.14.54
       esbuild-windows-64: 0.14.54
       esbuild-windows-arm64: 0.14.54
+    dev: true
 
   /esbuild@0.17.17:
     resolution: {integrity: sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==}


### PR DESCRIPTION
This will prevent problems like https://github.com/remix-run/remix/issues/6288#issuecomment-1585287474

---

BREAKING CHANGE: `esbuild` is now a peerDependency